### PR TITLE
`android update project` is not available in latest SDKs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,9 @@ if [ "$#" -gt 0 -a "$1" = "-h" ]; then
 fi
 
 [ -e project/local.properties ] || {
-	android update project -p project || exit 1
+	# android update project -p project || exit 1
+	echo "ndk.dir=$NDK_HOME" > project/local.properties
+	echo "sdk.dir=$ANDROID_HOME" >> project/local.properties
 	rm -f project/src/Globals.java
 }
 

--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -563,11 +563,15 @@ function build()
 
     echo -n "Which android sdk version/API level do you want to apply?"
     read sdk_version
-    android update project -p $T/project -t android-$sdk_version
+    # android update project -p $T/project -t android-$sdk_version
+    echo "ndk.dir=$NDK_HOME" > $T/project/local.properties
+    echo "sdk.dir=$ANDROID_HOME" >> $T/project/local.properties
     if [ $? -ne 0 ]; then
         echo -n "Applying sdk version $sdk_version failed"
         echo -n "Try to apply the default level 15"
-        android update project -p project -t android-15 -s
+        # android update project -p project -t android-15 -s
+        echo "ndk.dir=$NDK_HOME" > project/local.properties
+        echo "sdk.dir=$ANDROID_HOME" >> project/local.properties
     fi
 
     install_apk=false
@@ -597,7 +601,9 @@ function build()
     fi
 
     [ -e $T/project/local.properties ] || {
-            android update project -p project || exit 1
+            # android update project -p project || exit 1
+            echo "ndk.dir=$NDK_HOME" > project/local.properties
+            echo "sdk.dir=$ANDROID_HOME" >> project/local.properties
             rm -f project/src/Globals.java
     }
 # Set here your own NDK path if needed

--- a/buildall.sh
+++ b/buildall.sh
@@ -120,7 +120,9 @@ if ! $quick_rebuild ; then
 
   ./changeAppSettings.sh -a
 
-  android update project -p project
+  # android update project -p project
+  echo "ndk.dir=$NDK_HOME" > project/local.properties
+  echo "sdk.dir=$ANDROID_HOME" >> project/local.properties
 
   ./build.sh
 else

--- a/changeAppSettings.sh
+++ b/changeAppSettings.sh
@@ -963,15 +963,23 @@ else
 		ln -s -f $SDK_DIR/extras/android/compatibility/v4/android-support-v4.jar project/libs
 	}
 	[ -e $SDK_DIR/extras/google/google_play_services/libproject/google-play-services_lib/build.xml ] || \
-		android update project -t android-23 -p $SDK_DIR/extras/google/google_play_services/libproject/google-play-services_lib
+		# android update project -t android-23 -p $SDK_DIR/extras/google/google_play_services/libproject/google-play-services_lib
+		echo "ndk.dir=$NDK_HOME" > $SDK_DIR/extras/google/google_play_services/libproject/google-play-services_lib/local.properties
+		echo "sdk.dir=$ANDROID_HOME" >> $SDK_DIR/extras/google/google_play_services/libproject/google-play-services_lib/local.properties
 	[ -e $SDK_DIR/extras/android/compatibility/v7/mediarouter/build.xml ] || { \
-		android update project -t android-23 -p $SDK_DIR/extras/android/compatibility/v7/mediarouter
+		# android update project -t android-23 -p $SDK_DIR/extras/android/compatibility/v7/mediarouter
+		echo "ndk.dir=$NDK_HOME" > $SDK_DIR/extras/android/compatibility/v7/mediarouter/local.properties
+		echo "sdk.dir=$ANDROID_HOME" >> $SDK_DIR/extras/android/compatibility/v7/mediarouter/local.properties
 		echo 'android.library.reference.1=../../../../../../../../../../../../../../${sdk.dir}/extras/android/compatibility/v7/appcompat' >> $SDK_DIR/extras/android/compatibility/v7/mediarouter/local.properties
 	}
 	[ -e $SDK_DIR/extras/android/compatibility/v7/appcompat/build.xml ] || \
-		android update project -t android-23 -p $SDK_DIR/extras/android/compatibility/v7/appcompat
+		# android update project -t android-23 -p $SDK_DIR/extras/android/compatibility/v7/appcompat
+		echo "ndk.dir=$NDK_HOME" > $SDK_DIR/extras/android/compatibility/v7/appcompat/local.properties
+		echo "sdk.dir=$ANDROID_HOME" >> $SDK_DIR/extras/android/compatibility/v7/appcompat/local.properties
 	[ -e $SDK_DIR/extras/android/compatibility/v7/palette/build.xml ] || \
-		android update project -t android-23 -p $SDK_DIR/extras/android/compatibility/v7/palette && \
+		# android update project -t android-23 -p $SDK_DIR/extras/android/compatibility/v7/palette && \
+		echo "ndk.dir=$NDK_HOME" > $SDK_DIR/extras/android/compatibility/v7/palette/local.properties
+		echo "sdk.dir=$ANDROID_HOME" >> $SDK_DIR/extras/android/compatibility/v7/palette/local.properties
 		mkdir -p $SDK_DIR/extras/android/compatibility/v7/palette/src
 fi
 


### PR DESCRIPTION
replaced outdated `android update project` statements.
Sadly, `openarena` still won't be able to build cause modern Android SDK has no `ant` support - but at least all native parts are built successfully.